### PR TITLE
Add StreamsCharts saved HTML recovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TwitchUnjail
-Twitch vod downloader offering good speeds and low cpu utilization. Supports recovering vods using twitchtracker.com or streamscharts.com links.
+Twitch vod downloader offering good speeds and low cpu utilization. Supports recovering vods using twitchtracker.com or streamscharts.com links, including saved HTML exports created via Chrome's "View Source" option.
 
 Application can either be controlled via command line arguments or by entering data interactivly.
 

--- a/TwitchUnjail.Cli/Program.Cli.cs
+++ b/TwitchUnjail.Cli/Program.Cli.cs
@@ -55,6 +55,10 @@ namespace TwitchUnjail.Cli {
                     Console.WriteLine("Switching to recovery mode.");
                     /* Retrieve recovery info */
                     recoveryInfo = await StreamsChartsHandler.RetrieveInfo(videoUrl);
+                } else if (File.Exists(videoUrl)) {
+                    Console.WriteLine("Switching to recovery mode.");
+                    /* Retrieve recovery info */
+                    recoveryInfo = await StreamsChartsHandler.RetrieveInfoFromSavedHtml(videoUrl);
                 } else {
                     throw new Exception($"The given url is not a known vod url: '{videoUrl}'");
                 }
@@ -175,6 +179,10 @@ namespace TwitchUnjail.Cli {
                     Console.WriteLine("Switching to recovery mode.");
                     /* Retrieve recovery info */
                     recoveryInfo = await StreamsChartsHandler.RetrieveInfo(videoUrl);
+                } else if (File.Exists(videoUrl)) {
+                    Console.WriteLine("Switching to recovery mode.");
+                    /* Retrieve recovery info */
+                    recoveryInfo = await StreamsChartsHandler.RetrieveInfoFromSavedHtml(videoUrl);
                 } else {
                     throw new Exception($"The given url is not a known vod url: '{videoUrl}'");
                 }

--- a/TwitchUnjail.Cli/Program.Interactive.cs
+++ b/TwitchUnjail.Cli/Program.Interactive.cs
@@ -32,17 +32,22 @@ namespace TwitchUnjail.Cli {
                 
                 VodRecoveryInfo recoveryInfo;
                 if (vodUrl != null && vodUrl.Contains("twitchtracker.com", StringComparison.OrdinalIgnoreCase)) {
-                    
+
                     Console.WriteLine("Switching to recovery mode.");
                     /* Retrieve recovery info */
                     recoveryInfo = await TwitchTrackerHandler.RetrieveInfo(vodUrl);
                 } else if (vodUrl != null && vodUrl.Contains("streamscharts.com", StringComparison.OrdinalIgnoreCase)) {
-                    
+
                     Console.WriteLine("Switching to recovery mode.");
                     /* Retrieve recovery info */
                     recoveryInfo = await StreamsChartsHandler.RetrieveInfo(vodUrl);
+                } else if (vodUrl != null && File.Exists(vodUrl)) {
+
+                    Console.WriteLine("Switching to recovery mode.");
+                    /* Retrieve recovery info */
+                    recoveryInfo = await StreamsChartsHandler.RetrieveInfoFromSavedHtml(vodUrl);
                 } else {
-                    
+
                     throw new Exception($"The given url is not a known vod url: '{vodUrl}'");
                 }
                 

--- a/TwitchUnjail.Core/StreamsChartsHandler.SavedHtml.cs
+++ b/TwitchUnjail.Core/StreamsChartsHandler.SavedHtml.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using TwitchUnjail.Core.Models;
+
+namespace TwitchUnjail.Core {
+
+    public static partial class StreamsChartsHandler {
+
+        private static readonly Regex StreamsChartsSavedHtmlUrlRegex = new("<meta[^>]+property=['\"]og:url['\"][^>]+content=['\"]([^'\"]+)['\"]", RegexOptions.IgnoreCase);
+
+        public static ValueTask<VodRecoveryInfo> RetrieveInfoFromSavedHtml(string filePath) {
+            if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath)) {
+                throw new Exception("Saved streamscharts.com html file could not be found.");
+            }
+
+            var streamsChartsHtml = File.ReadAllText(filePath);
+            var urlMatch = StreamsChartsSavedHtmlUrlRegex.Match(streamsChartsHtml);
+            if (!urlMatch.Success || urlMatch.Groups.Count != 2) {
+                throw new Exception("Saved streamscharts.com html file does not reference a valid stream url.");
+            }
+
+            var url = urlMatch.Groups[1].Value;
+
+            try {
+                return ValueTask.FromResult(ParseVodRecoveryInfo(url, streamsChartsHtml));
+            } catch (Exception) {
+                throw new Exception("Saved streamscharts.com html file is not a valid stream page or the page structure has recently changed and is no longer readable.");
+            }
+        }
+    }
+}

--- a/TwitchUnjail.Core/StreamsChartsHandler.cs
+++ b/TwitchUnjail.Core/StreamsChartsHandler.cs
@@ -10,32 +10,39 @@ namespace TwitchUnjail.Core {
         private static readonly Regex StreamsChartsRegex = new("streamscharts\\.com\\/channels\\/([a-z0-9_-]+)\\/streams\\/([0-9]+)", RegexOptions.IgnoreCase);
         
         public static async ValueTask<VodRecoveryInfo> RetrieveInfo(string url) {
+            if (!StreamsChartsRegex.IsMatch(url)) {
+                throw new Exception("Url is not a valid streamscharts.com stream url");
+            }
+
+            try {
+                var streamsChartsHtml = await HttpHelper.GetHttp(url);
+                return ParseVodRecoveryInfo(url, streamsChartsHtml);
+            } catch (Exception) {
+                throw new Exception("Url is not a valid streamscharts.com stream url or the page structure has recently changed and is no longer readable.");
+            }
+        }
+
+        private static VodRecoveryInfo ParseVodRecoveryInfo(string url, string streamsChartsHtml) {
             var matches = StreamsChartsRegex.Match(url);
 
             if (!matches.Success || matches.Groups.Count != 3) {
                 throw new Exception("Url is not a valid streamscharts.com stream url");
             }
 
-            try {
-                var channelName = matches.Groups[1].Value;
-                var broadcastId = long.Parse(matches.Groups[2].Value);
+            var channelName = matches.Groups[1].Value;
+            var broadcastId = long.Parse(matches.Groups[2].Value);
+            var displayNameLine = streamsChartsHtml.Substring(streamsChartsHtml.IndexOf("<title>"));
+            var displayName = displayNameLine.Substring(displayNameLine.IndexOf(">") + 1, displayNameLine.IndexOf(" stream analytics") - displayNameLine.IndexOf(">") - 1).Trim();
+            var dateLine = streamsChartsHtml.Substring(streamsChartsHtml.IndexOf("<time class=\"") + 10);
+            var dateStringParts = dateLine.Substring(dateLine.IndexOf("datetime=\"") + 10, dateLine.IndexOf("\">") - dateLine.IndexOf("datetime=\"") - 10).Trim().Split(' ');
 
-                var streamsChartsHtml = await HttpHelper.GetHttp(url);
-                var displayNameLine = streamsChartsHtml.Substring(streamsChartsHtml.IndexOf("<title>"));
-                var displayName = displayNameLine.Substring(displayNameLine.IndexOf(">") + 1, displayNameLine.IndexOf(" stream analytics") - displayNameLine.IndexOf(">") - 1).Trim();
-                var dateLine = streamsChartsHtml.Substring(streamsChartsHtml.IndexOf("<time class=\"") + 10);
-                var dateStringParts = dateLine.Substring(dateLine.IndexOf("datetime=\"") + 10, dateLine.IndexOf("\">") - dateLine.IndexOf("datetime=\"") - 10).Trim().Split(' ');
-
-                return new VodRecoveryInfo {
-                    Url = url,
-                    BroadcastId = broadcastId,
-                    ChannelName = channelName,
-                    ChannelDisplayName = displayName,
-                    RecordDate = DateTime.Parse($"{string.Join("-", dateStringParts[0].Split('-').Reverse())} {dateStringParts[1]}", CultureInfo.InvariantCulture),
-                };
-            } catch (Exception) {
-                throw new Exception("Url is not a valid streamscharts.com stream url or the page structure has recently changed and is no longer readable.");
-            }
+            return new VodRecoveryInfo {
+                Url = url,
+                BroadcastId = broadcastId,
+                ChannelName = channelName,
+                ChannelDisplayName = displayName,
+                RecordDate = DateTime.Parse($"{string.Join("-", dateStringParts[0].Split('-').Reverse())} {dateStringParts[1]}", CultureInfo.InvariantCulture),
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a StreamsCharts handler that can parse saved HTML exports to recover VOD metadata
- allow CLI and interactive modes to detect local Streamscharts files and use the saved HTML handler
- document saved HTML recovery support in the README

## Testing
- `dotnet build` *(fails: dotnet is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e310eb41ac83278d8ed650ca493cfb